### PR TITLE
Support for Swift package manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let name = "JoyConSwift"
+
+let package = Package(
+    name: name,
+    platforms: [.macOS("10.14")],
+    products: [.library(name: name, targets: [name])],
+	targets: [.target(name: name, path: "Source")],
+	swiftLanguageVersions: [.v5]
+)


### PR DESCRIPTION
Adds Swift Package Manager support by introducing a `Package.swift` manifest for the existing macOS library.

Scope:
- No intended behavior change to the library itself
- Keeps the package macOS-only, matching the current IOKit-based implementation
- Makes the library easier to consume in modern Xcode/SPM-based projects